### PR TITLE
Allow serialization of only whitelisted keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ internal function, but set different options by default:
 * nohuge (true/False) -- disable checking numbers against undefined and huge values
 * maxlevel (number) -- specify max level up to which to expand nested tables
 * ignore (table) -- allows to specify a list of values to ignore (as keys)
-* keywhitelist (table) -- allows to specify the list of keys to be serialized. Any keys not in this list are not included in final output (as keys)
+* keyallow (table) -- allows to specify the list of keys to be serialized. Any keys not in this list are not included in final output (as keys)
 * custom (function) -- provide custom output for tables
 
 These options can be provided as a second parameter to Serpent functions.

--- a/src/serpent.lua
+++ b/src/serpent.lua
@@ -67,7 +67,7 @@ local function s(t, opts)
       for n, key in ipairs(o) do
         local value, ktype, plainindex = t[key], type(key), n <= maxn and not sparse
         if opts.ignore and opts.ignore[value] -- skip ignored values; do nothing
-        or opts.keywhitelist and not opts.keywhitelist[key]
+        or opts.keyallow and not opts.keyallow[key]
         or sparse and value == nil then -- skipping nils; do nothing
         elseif ktype == 'table' or ktype == 'function' or badtype[ktype] then
           if not seen[key] and not globals[key] then

--- a/t/test.lua
+++ b/t/test.lua
@@ -66,11 +66,11 @@ assert(_a.list['3'] == 33, "string that looks like number as index: failed")
 assert(_a.list[4] == 'f', "specific table element preserves its value: failed")
 assert(_a.ignore == nil, "ignored table not serialized: failed")
 
--- test whitelisting keys
-_a = assert(loadstring(serpent.dump(a, {keywhitelist = {["list"] = true, ["x"] = true}})))()
-assert(_a.x == 1, "whitelisting key 'x': failed")
-assert(_a.list ~= nil, "whitelisting key 'list': failed")
-assert(_a[_c] == nil, "not whitelisting key '_c': failed")
+-- test allowing keys
+_a = assert(loadstring(serpent.dump(a, {keyallow = {["list"] = true, ["x"] = true}})))()
+assert(_a.x == 1, "allowing key 'x': failed")
+assert(_a.list ~= nil, "allowing key 'list': failed")
+assert(_a[_c] == nil, "not allowing key '_c': failed")
 
 -- test without sparsness to check the number of elements in the list with nil
 _a = assert(loadstring(serpent.dump(a, {sparse = false})))()


### PR DESCRIPTION
Example:

```
local a = {
    foo = 'bar',
    [1] = 2,
    [true] = 'only me'
}

local options = {
    keywhitelist = {
        ['foo'] = true,
        [true] = true
    },
    ignore = {
        ['bar'] = true
    }
}

print(serpent.block(a, options))

-- output:

{
    [true] = "only me"
}
```
