### PR TITLE
Added valtypeignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ internal function, but set different options by default:
 * maxlevel (number) -- specify max level up to which to expand nested tables
 * ignore (table) -- allows to specify a list of values to ignore (as keys)
 * keyallow (table) -- allows to specify the list of keys to be serialized. Any keys not in this list are not included in final output (as keys)
+* valtypeignore (table) -- allows to specify a list of value *types* to ignore (as keys)
 * custom (function) -- provide custom output for tables
 
 These options can be provided as a second parameter to Serpent functions.

--- a/src/serpent.lua
+++ b/src/serpent.lua
@@ -68,6 +68,7 @@ local function s(t, opts)
         local value, ktype, plainindex = t[key], type(key), n <= maxn and not sparse
         if opts.ignore and opts.ignore[value] -- skip ignored values; do nothing
         or opts.keyallow and not opts.keyallow[key]
+        or opts.valtypeignore and opts.valtypeignore[type(value)] -- skipping ignored value types
         or sparse and value == nil then -- skipping nils; do nothing
         elseif ktype == 'table' or ktype == 'function' or badtype[ktype] then
           if not seen[key] and not globals[key] then

--- a/t/test.lua
+++ b/t/test.lua
@@ -72,6 +72,14 @@ assert(_a.x == 1, "allowing key 'x': failed")
 assert(_a.list ~= nil, "allowing key 'list': failed")
 assert(_a[_c] == nil, "not allowing key '_c': failed")
 
+-- test ignore value types
+_a = assert(loadstring(serpent.dump(a, {valtypeignore = {["function"] = true, ["table"] = true}})))()
+assert(_a.z == nil, "ignoring value type 'function': failed")
+assert(_a[c] == nil, "ignoring value type 'function': failed")
+assert(_a.list == nil, "ignoring value type 'table': failed")
+assert(_a['true'] ~= nil, "not ignoring value type 'string': failed")
+assert(_a.x ~= nil, "not ignoring value type 'number': failed")
+
 -- test without sparsness to check the number of elements in the list with nil
 _a = assert(loadstring(serpent.dump(a, {sparse = false})))()
 assert(#(_a.list) == #(a.list), "size of array part stays the same: failed")


### PR DESCRIPTION
This allows, for example, serializing of tables where you're only concerned with `number`, `string`, and `boolean` types

Usage:

``` lua
local a = {
    x = 'hello',
    y = function() return 1 end,
    z = 10
}

local options = {
    valtypeignore = {
        ['function'] = true,
        ['number'] = true
    }
}

print(serpent.block(a, options))

-- output:
{
  x = "hello"
}
```
