### PR TITLE
Add CI with code coverage using Travis CI and Codecov

### DIFF
--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,3 @@
+modules = {
+  ["serpent"] = "src/serpent.lua"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+sudo: false
+
+env:
+  - LUA="lua=5.1"
+  - LUA="lua=5.2"
+  - LUA="lua=5.3"
+  - LUA="luajit=2.0"
+  - LUA="luajit=2.1"
+
+before_install:
+  - pip install codecov
+  - pip install hererocks
+  - hererocks lua_install --$LUA -r latest
+  - source lua_install/bin/activate
+  - luarocks install cluacov
+
+install:
+  - luarocks make
+
+script:
+  - lua -lluacov t/test.lua
+
+after_script:
+  - luacov
+  - codecov -X gcov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Serpent
 
+[![Build Status](https://travis-ci.org/pkulchenko/serpent.svg?branch=master)](https://travis-ci.org/pkulchenko/serpent)
+[![Coverage status](https://codecov.io/gh/pkulchenko/serpent/branch/master/graph/badge.svg)](https://codecov.io/gh/pkulchenko/serpent)
+
 Lua serializer and pretty printer.
 
 ## Features


### PR DESCRIPTION
This adds configuration for Travis CI to run `t/test.lua` on each commit under Lua 5.1, 5.2, 5.3, and LuaJIT 2.0, 2.1.

It looks like this: https://travis-ci.org/mpeterv/serpent

Additionally, test coverage is collected using Luacov and uploaded to Codecov. Looks like this: https://codecov.io/gh/mpeterv/serpent/branch/ci

Coverage is pretty good, only two `if` branches are not touched by existing tests.

Also, add nice badges to readme to make it easy to see if the build if failing currently and what is the current coverage percentage.