### PR TITLE
Fixed handling of floating point numbers in comma decimal locale's.

### DIFF
--- a/src/serpent.lua
+++ b/src/serpent.lua
@@ -23,7 +23,7 @@ local function s(t, opts)
   local function gensym(val) return '_'..(tostring(tostring(val)):gsub("[^%w]",""):gsub("(%d%w+)",
     -- tostring(val) is needed because __tostring may return a non-string value
     function(s) if not syms[s] then symn = symn+1; syms[s] = symn end return tostring(syms[s]) end)) end
-  local function safestr(s) return type(s) == "number" and tostring(huge and snum[tostring(s)] or numformat:format(s))
+  local function safestr(s) return type(s) == "number" and tostring(huge and snum[tostring(s)] or numformat:format(s)):gsub('%,','.')
     or type(s) ~= "string" and tostring(s) -- escape NEWLINE/010 and EOF/026
     or ("%q"):format(s):gsub("\010","n"):gsub("\026","\\026") end
   local function comment(s,l) return comm and (l or 0) < comm and ' --[['..select(2, pcall(tostring, s))..']]' or '' end


### PR DESCRIPTION
By fixing issue #36 with this methodology we do not have to worry about changing the locale via os.setlocale. This will work with any locale, across any system, without any intervention of the user.

Closes #36